### PR TITLE
Accept keen-js client instance, don't create one

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ npm install --save redux-keen
 
 ```js
 import keenAnalytics from 'redux-keen';
+import Keen from 'keen-js';
 
-let keenMiddleware = keenAnalytics('YOUR_PROJECT_ID', 'YOUR_WRITE_KEY');
+let keenClient = new Keen({ projectId: 'YOUR_PROJECT_ID', writeKey: 'YOUR_WRITE_KEY' });
+let keenMiddleware = keenAnalytics(keenClient);
 ```
 
-The default export is a function requiring Keen IO project id and API write key. This function returns a middleware function, that can be applied using `applyMiddleware` from [Redux](http://rackt.github.io/redux).
+The default export is a function requiring [keen-js](https://github.com/keen/keen-js) client instance. This function returns a middleware function, that can be applied using `applyMiddleware` from [Redux](http://rackt.github.io/redux).
 
 If it receives an action whose `meta` property contains an `analytics` property with non-empty `collection` property, it will record the event in the Keen IO analytics.
 

--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
   ],
   "author": "Pavel Volek <me@pavelvolek.cz>",
   "license": "MIT",
-  "dependencies": {
-    "keen-js": "^3.2.7"
-  },
   "devDependencies": {
     "babel": "^5.8.23",
     "mocha": "^2.3.2"

--- a/src/index.js
+++ b/src/index.js
@@ -4,11 +4,9 @@ function isFunction(val) {
   return typeof val === 'function';
 }
 
-export default function keenAnalytics(projectId, writeKey, getGlobals) {
-  if (!projectId) throw new Error('You must provide a project id.');
-  if (!writeKey) throw new Error('You must provide a write key required for sending data.');
+export default function keenAnalytics(keenClient, getGlobals) {
+  if (!keenClient || !keenClient.addEvent) throw new Error('You must provide a keen-js client instance.');
 
-  let keenClient = new Keen({ projectId, writeKey });
   let globals = {};
 
   return store => next => action => {


### PR DESCRIPTION
This is a breaking API change, but it has several major benefits:
- Users are free to manage the version of `keen-js` independently of your wrapper. This has the nice side effect of reducing maintenance on this library since you'll never need to bump the version yourself.
- Users have direct control over the instance, which means they can use it outside of the Redux flow if required.
- While there are no tests in this pull request, this will greatly aid testing since you can easily pass in a mock keen-js client and assert that `addEvent` was called correctly.
- I personally felt the need to check the code as soon as I realised I was required to hand over my Keen API keys :wink: Handing over the instance feels like a better separation of concerns in this regard.

What are your thoughts?
